### PR TITLE
Update Substack RSS feed URL

### DIFF
--- a/script.js
+++ b/script.js
@@ -133,7 +133,7 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
     const newsList = document.getElementById('ai-news-list');
-    const rssFeedUrl = 'https://yapayzeka101.substack.com/feed';
+    const rssFeedUrl = 'https://airadartr.substack.com/feed';
     // Using RSS2JSON API to fetch and convert the RSS feed to JSON
     const apiUrl = `https://api.rss2json.com/v1/api.json?rss_url=${encodeURIComponent(rssFeedUrl)}`;
 


### PR DESCRIPTION
## Summary
- Updated RSS feed URL from `yapayzeka101.substack.com` to `airadartr.substack.com`
- Maintains existing RSS2JSON integration and latest AI news functionality

## Test plan
- [x] Verify RSS feed URL change in script.js
- [ ] Test that latest AI news section loads correctly with new feed
- [ ] Confirm RSS2JSON API works with new Substack URL

🤖 Generated with [Claude Code](https://claude.ai/code)