### PR TITLE
Update Substack newsletter iframe URL

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -69,7 +69,7 @@
              <h2 data-i18n="common_newsletter.newsletter_signup_title"></h2> <!-- English version of "AI Bülten'e Üye Ol" -->
              <div class="substack-embed-wrapper">
                 <!-- The iframe provided by the user -->
-                <iframe src="https://yapayzeka101.substack.com/embed" width="400" height="320" style="background:white; max-width: 100%;" frameborder="0" scrolling="no" title="Subscribe to Yapay Zeka 101 Newsletter"></iframe>
+                <iframe src="https://airadartr.substack.com/embed" width="400" height="320" style="background:white; max-width: 100%;" frameborder="0" scrolling="no" title="Subscribe to Yapay Zeka 101 Newsletter"></iframe>
              </div>
         </section>
 

--- a/contact.html
+++ b/contact.html
@@ -101,7 +101,7 @@
              <h2 data-i18n="common_newsletter.newsletter_signup_title"></h2> <!-- English version of "AI Bülten'e Üye Ol" -->
              <div class="substack-embed-wrapper">
                 <!-- The iframe provided by the user -->
-                <iframe src="https://yapayzeka101.substack.com/embed" width="400" height="320" style="background:white; max-width: 100%;" frameborder="0" scrolling="no" title="Subscribe to Yapay Zeka 101 Newsletter"></iframe>
+                <iframe src="https://airadartr.substack.com/embed" width="400" height="320" style="background:white; max-width: 100%;" frameborder="0" scrolling="no" title="Subscribe to Yapay Zeka 101 Newsletter"></iframe>
              </div>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
              <h2 data-i18n="common_newsletter.newsletter_signup_title"></h2> <!-- English version of "AI Bülten'e Üye Ol" -->
              <div class="substack-embed-wrapper">
                 <!-- The iframe provided by the user -->
-                <iframe src="https://yapayzeka101.substack.com/embed" width="400" height="320" style="background:white; max-width: 100%;" frameborder="0" scrolling="no" title="Subscribe to Yapay Zeka 101 Newsletter"></iframe>
+                <iframe src="https://airadartr.substack.com/embed" width="400" height="320" style="background:white; max-width: 100%;" frameborder="0" scrolling="no" title="Subscribe to Yapay Zeka 101 Newsletter"></iframe>
              </div>
         </section>
 


### PR DESCRIPTION
## Summary
- Update Substack embed URL from `yapayzeka101.substack.com` to `airadartr.substack.com`
- Applied across all pages: index.html, blog.html, contact.html
- Maintains all existing iframe parameters (width, height, styling)

## Test plan
- [ ] Verify new Substack embed loads correctly on all pages
- [ ] Test newsletter subscription functionality
- [ ] Check responsive behavior on mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)