### PR TITLE
Update AI banner to show Claude Code replacing GitHub Copilot

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -10,7 +10,7 @@
   },
   "common_banner": {
     "ai_built_by": "Built by AI, Content by Humans — Crafted with Love.",
-    "ai_human_words": "ChatGPT o3, Claude 3.7 Sonnet, Gemini 2.5 Pro, GitHub Copilot"
+    "ai_human_words": "ChatGPT o3, Claude 3.7 Sonnet, Gemini 2.5 Pro, <span class=\"strikethrough\">GitHub Copilot</span> Claude Code"
   },
   "common_footer": {
     "copyright_text": "© 2025 C. Murad Özsert",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -10,7 +10,7 @@
   },
   "common_banner": {
     "ai_built_by": "Yapay Zekâ Asistanları ile Geliştirildi.",
-    "ai_human_words": "ChatGPT o3, Claude 3.7 Sonnet, Gemini 2.5 Pro, GitHub Copilot"
+    "ai_human_words": "ChatGPT o3, Claude 3.7 Sonnet, Gemini 2.5 Pro, <span class=\"strikethrough\">GitHub Copilot</span> Claude Code"
   },
   "common_footer": {
     "copyright_text": "© 2025 C. Murad Özsert",

--- a/style.css
+++ b/style.css
@@ -150,6 +150,12 @@
     color: rgba(51, 51, 51, 0.9);
 }
 
+.strikethrough {
+    text-decoration: line-through;
+    color: rgba(51, 51, 51, 0.6);
+    transition: all 0.3s ease;
+}
+
 /* Animation for banner appearance */
 @keyframes fadeSlideUp {
     0% {


### PR DESCRIPTION
## Summary
- Replace GitHub Copilot with strikethrough effect in AI banner
- Add Claude Code as the new tool being used
- Applied across both Turkish and English translation files
- Added CSS styling for strikethrough effect with subtle visual treatment

## Changes
- Updated `locales/tr.json` and `locales/en.json` with new banner text
- Added `.strikethrough` CSS class with line-through decoration and faded color
- Visual effect shows transition from GitHub Copilot to Claude Code

🤖 Generated with [Claude Code](https://claude.ai/code)