### PR TITLE
Fix Substack URL consistency across HTML files

### DIFF
--- a/about.html
+++ b/about.html
@@ -161,7 +161,7 @@
              <h2 data-i18n="common_newsletter.newsletter_signup_title"></h2> <!-- English version of "AI Bülten'e Üye Ol" -->
              <div class="substack-embed-wrapper">
                 <!-- The iframe provided by the user -->
-                <iframe src="https://yapayzeka101.substack.com/embed" width="400" height="320" style="background:white; max-width: 100%;" frameborder="0" scrolling="no" title="Subscribe to Yapay Zeka 101 Newsletter"></iframe>
+                <iframe src="https://airadartr.substack.com/embed" width="400" height="320" style="background:white; max-width: 100%;" frameborder="0" scrolling="no" title="Subscribe to Yapay Zeka 101 Newsletter"></iframe>
              </div>
         </section>
 

--- a/topics.html
+++ b/topics.html
@@ -287,7 +287,7 @@
              <h2 data-i18n="common_newsletter.newsletter_signup_title"></h2> <!-- English version of "AI Bülten'e Üye Ol" -->
              <div class="substack-embed-wrapper">
                 <!-- The iframe provided by the user -->
-                <iframe src="https://yapayzeka101.substack.com/embed" width="400" height="320" style="background:white; max-width: 100%;" frameborder="0" scrolling="no" title="Subscribe to Yapay Zeka 101 Newsletter"></iframe>
+                <iframe src="https://airadartr.substack.com/embed" width="400" height="320" style="background:white; max-width: 100%;" frameborder="0" scrolling="no" title="Subscribe to Yapay Zeka 101 Newsletter"></iframe>
              </div>
         </section>
 


### PR DESCRIPTION
## Summary
- Updated about.html and topics.html to use correct `airadartr.substack.com` Substack URL
- Ensures consistent newsletter integration across all pages
- Fixes inconsistency where some pages used `yapayzeka101.substack.com`

## Test plan
- [x] Verify all HTML files now use the same Substack URL
- [x] Test newsletter signup functionality on affected pages

🤖 Generated with [Claude Code](https://claude.ai/code)