### PR TITLE
Enhance newsletter bento layout with prominent first item

### DIFF
--- a/script.js
+++ b/script.js
@@ -157,12 +157,13 @@ document.addEventListener('DOMContentLoaded', function () {
                 let html = "";
 
                 // Define bento layout patterns for different numbers of items
+                // First item is always 2x2 (handled by CSS :first-child)
                 const bentoPatterns = {
                     1: ['bento-large'],
-                    2: ['bento-large', 'bento-tall'],
-                    3: ['bento-wide', 'bento-regular', 'bento-regular'],
-                    4: ['bento-large', 'bento-regular', 'bento-regular', 'bento-tall'],
-                    5: ['bento-large', 'bento-wide', 'bento-regular', 'bento-regular', 'bento-tall']
+                    2: ['bento-large', 'bento-regular'],
+                    3: ['bento-large', 'bento-regular', 'bento-regular'],
+                    4: ['bento-large', 'bento-regular', 'bento-regular', 'bento-regular'],
+                    5: ['bento-large', 'bento-regular', 'bento-regular', 'bento-regular', 'bento-regular']
                 };
 
                 const itemCount = Math.min(items.length, 5);

--- a/script.js
+++ b/script.js
@@ -156,6 +156,18 @@ document.addEventListener('DOMContentLoaded', function () {
                 const items = data.items;
                 let html = "";
 
+                // Define bento layout patterns for different numbers of items
+                const bentoPatterns = {
+                    1: ['bento-large'],
+                    2: ['bento-large', 'bento-tall'],
+                    3: ['bento-wide', 'bento-regular', 'bento-regular'],
+                    4: ['bento-large', 'bento-regular', 'bento-regular', 'bento-tall'],
+                    5: ['bento-large', 'bento-wide', 'bento-regular', 'bento-regular', 'bento-tall']
+                };
+
+                const itemCount = Math.min(items.length, 5);
+                const pattern = bentoPatterns[itemCount] || bentoPatterns[5];
+
                 items.forEach((item, index) => {
                     // Limiting to 5 posts, adjust as needed
                     if (index < 5) {
@@ -197,8 +209,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
                         // Prepare inline style for background image
                         const styleAttribute = imageUrl ? `style="background-image: url('${imageUrl}');"` : 'style="background-color: var(--light-gray);"'; // Fallback background color
+                        
+                        // Get bento class for this item
+                        const bentoClass = pattern[index] || 'bento-regular';
 
-                        html += `<li ${styleAttribute}>
+                        html += `<li class="${bentoClass}" ${styleAttribute}>
                                     <div class="ai-news-content">
                                         <h3>${title}</h3>
                                         <p>${descriptionSnippet}</p>

--- a/style.css
+++ b/style.css
@@ -468,39 +468,51 @@ section:nth-of-type(odd) { /* Alternate background colors (optional) */
 #ai-news-list {
     list-style: none;
     padding: 0;
-    margin: 0 auto; /* Center the list container */
-    display: flex; /* Enable flexbox for horizontal layout */
-    overflow-x: auto; /* Allow horizontal scrolling */
-    padding-bottom: 20px; /* Add some padding for the scrollbar */
-    scroll-behavior: smooth;
-    scrollbar-width: none; /* Firefox */
-    -ms-overflow-style: none; /* IE and Edge */
-    gap: 22px; /* Consistent spacing between items */
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-auto-rows: 200px;
+    gap: 16px;
+    padding-bottom: 20px;
+    max-width: 1200px;
 }
 
-#ai-news-list::-webkit-scrollbar {
-    display: none; /* Chrome, Safari, Opera */
+/* Bento layout size variations */
+#ai-news-list li.bento-large {
+    grid-column: span 2;
+    grid-row: span 2;
+}
+
+#ai-news-list li.bento-wide {
+    grid-column: span 2;
+    grid-row: span 1;
+}
+
+#ai-news-list li.bento-tall {
+    grid-column: span 1;
+    grid-row: span 2;
+}
+
+#ai-news-list li.bento-regular {
+    grid-column: span 1;
+    grid-row: span 1;
 }
 
 #ai-news-list li {
     border: 1px solid var(--border-color);
-    border-radius: var(--border-radius-md); /* Consistent rounded corners */
-    margin-right: 0; /* Using gap instead */
-    margin-bottom: 0;
+    border-radius: var(--border-radius-md);
     position: relative;
     background-size: cover;
     background-position: center;
-    width: 350px;
-    height: 475px;
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
     padding: 0;
     overflow: hidden;
     color: white;
-    flex-shrink: 0;
     box-shadow: var(--shadow-sm);
     transition: transform var(--transition-normal), box-shadow var(--transition-normal);
+    min-height: 200px;
 }
 
 #ai-news-list li::before { /* Add a dark overlay for text readability */
@@ -853,19 +865,39 @@ footer {
 
 /* --- Responsiveness --- */
 
+@media (max-width: 1023px) and (min-width: 768px) {
+    #ai-news-list {
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        grid-auto-rows: 180px;
+    }
+    
+    /* Limit spans on tablet */
+    #ai-news-list li.bento-large {
+        grid-column: span 2;
+        grid-row: span 2;
+    }
+    
+    #ai-news-list li.bento-wide {
+        grid-column: span 2;
+        grid-row: span 1;
+    }
+}
+
 @media (max-width: 767px) {
     #ai-news-list {
-        flex-direction: column;
-        align-items: center;
-        overflow-x: visible; /* Disable horizontal scroll for vertical stacking */
+        grid-template-columns: 1fr;
+        grid-auto-rows: 250px;
+        max-width: 100%;
+        padding: 0 10px 20px;
     }
 
-    #ai-news-list li {
-        width: 90%; /* Responsive width for mobile */
-        max-width: 400px; /* Cap the width */
-        height: auto; /* Auto height for responsiveness */
-        margin-right: 0; /* Remove right margin */
-        margin-bottom: 20px; /* Add space between stacked items */
+    /* Override all bento classes on mobile for single column */
+    #ai-news-list li.bento-large,
+    #ai-news-list li.bento-wide,
+    #ai-news-list li.bento-tall,
+    #ai-news-list li.bento-regular {
+        grid-column: span 1;
+        grid-row: span 1;
     }
     
     #ai-topics-list {

--- a/style.css
+++ b/style.css
@@ -471,13 +471,19 @@ section:nth-of-type(odd) { /* Alternate background colors (optional) */
     margin: 0 auto;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    grid-auto-rows: 200px;
+    grid-auto-rows: 300px;
     gap: 16px;
     padding-bottom: 20px;
     max-width: 1200px;
 }
 
 /* Bento layout size variations */
+/* First item always takes 2x2 square */
+#ai-news-list li:first-child {
+    grid-column: span 2;
+    grid-row: span 2;
+}
+
 #ai-news-list li.bento-large {
     grid-column: span 2;
     grid-row: span 2;
@@ -868,7 +874,13 @@ footer {
 @media (max-width: 1023px) and (min-width: 768px) {
     #ai-news-list {
         grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-        grid-auto-rows: 180px;
+        grid-auto-rows: 260px;
+    }
+    
+    /* First item maintains 2x2 on tablet */
+    #ai-news-list li:first-child {
+        grid-column: span 2;
+        grid-row: span 2;
     }
     
     /* Limit spans on tablet */
@@ -886,7 +898,7 @@ footer {
 @media (max-width: 767px) {
     #ai-news-list {
         grid-template-columns: 1fr;
-        grid-auto-rows: 250px;
+        grid-auto-rows: 300px;
         max-width: 100%;
         padding: 0 10px 20px;
     }


### PR DESCRIPTION
## Summary
- Redesigned newsletter section with modern bento grid layout
- First newsletter item now displays as prominent 2×2 square
- Remaining items arranged in clean 1×1 grid pattern
- Increased item heights for better visual impact and readability

## Test plan
- [ ] Verify first newsletter item displays as large 2×2 square on desktop
- [ ] Confirm remaining items flow naturally in 1×1 grid pattern
- [ ] Test responsive behavior on tablet (first item remains 2×2)
- [ ] Validate mobile layout switches to single column
- [ ] Check newsletter content loads correctly from RSS feed
- [ ] Ensure hover effects and transitions work smoothly

🤖 Generated with [Claude Code](https://claude.ai/code)