### PR TITLE
Update navigation labels from Blog to Newsletter

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -3,7 +3,7 @@
     "logo_text": "C. Murad Özsert",
     "nav_about": "About",
     "nav_topics": "Speaking Topics",
-    "nav_blog": "Blog",
+    "nav_blog": "Newsletter",
     "nav_contact": "Contact",
     "lang_tr": "TR",
     "lang_en": "EN"

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -3,7 +3,7 @@
     "logo_text": "C. Murad Özsert",
     "nav_about": "Hakkında",
     "nav_topics": "Konuşma Başlıkları",
-    "nav_blog": "Blog",
+    "nav_blog": "Bülten",
     "nav_contact": "İletişim",
     "lang_tr": "TR",
     "lang_en": "EN"
@@ -21,7 +21,7 @@
     "section_title": "Haftalık Bülten",
     "newsletter_name": "The Next SignAl",
     "newsletter_description": "Finding the next signal in AI & Tech - Beyond the noise",
-    "newsletter_author": "C. Murad Özsert",
+    "newsletter_author": "By C. Murad Özsert",
     "subscribe_linkedin": "LinkedIn'de Takip Et",
     "subscribe_substack": "Substack'te Takip Et"
   },


### PR DESCRIPTION
## Summary
- Update navigation menu labels to better reflect the content
- Change "Blog" to "Newsletter" in English navigation
- Change "Blog" to "Bülten" (Newsletter) in Turkish navigation
- Fix author text formatting consistency in Turkish translations

## Changes
- **English Navigation**: "Blog" → "Newsletter"
- **Turkish Navigation**: "Blog" → "Bülten"
- **Author Text**: Standardize format across languages

This update better represents the actual content, which focuses on newsletter/bulletin rather than traditional blog posts.

🤖 Generated with [Claude Code](https://claude.ai/code)