### PR TITLE
Update font family from Open Sans to Lato

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 /* --- Font Import --- */
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700;900&display=swap');
 
 /* --- Basic Reset & Box Sizing --- */
 * {
@@ -24,7 +24,7 @@
     --content-padding: 20px;
     
     /* Typography */
-    --base-font-family: 'Open Sans', system-ui, -apple-system, sans-serif; /* Better fallbacks */
+    --base-font-family: 'Lato', system-ui, -apple-system, sans-serif; /* Better fallbacks */
     --base-font-size: 16px;
     --base-line-height: 1.6;
     --heading-line-height: 1.3;
@@ -506,7 +506,7 @@ section:nth-of-type(odd) { /* Alternate background colors (optional) */
     width: 280px;
     height: 44px;
     border-radius: 22px;
-    font-family: "SF Pro Text", Helvetica, sans-serif;
+    font-family: 'Lato', system-ui, -apple-system, sans-serif;
     font-weight: 600;
     font-size: 14px;
     transition: all 0.3s ease;


### PR DESCRIPTION
## Summary
- Replace site typography from Open Sans to Lato sans-serif font
- Update Google Fonts import and all font-family declarations
- Ensure consistent typography across all components

## Changes
- **Google Fonts Import**: Open Sans → Lato (weights: 300, 400, 700, 900)
- **CSS Variable**: Updated `--base-font-family` to use Lato
- **Newsletter Buttons**: Changed from SF Pro Text to Lato for consistency
- **Fallbacks**: Maintained system font fallbacks for performance

## Benefits
- Modern, clean sans-serif typography
- Better readability and professional appearance
- Consistent font usage across all site elements
- Optimized font weights for design flexibility

🤖 Generated with [Claude Code](https://claude.ai/code)